### PR TITLE
[SERV-1095] Update tag name for release to Docker files 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
         context: .
         file: ./Dockerfile
         push: true
-        tags: ${{ secrets.DOCKER_REGISTRY_ACCOUNT }}pairtree-service:${{ github.event.release.tag_name }}
+        tags: ${{ vars.DOCKER_REGISTRY_ACCOUNT }}pairtree-service:${{ github.ref_name }}
         build-args: |
           GO_VERSION=${{ env.GO_VERSION }}
           ALPINE_VERSION=${{ env.ALPINE_VERSION }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ on:
     types: [ published ]
   schedule:
     - cron:  '20 20 * * *'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         context: .
         file: ./Dockerfile
         push: true
-        tags: ${{ secrets.DOCKER_REGISTRY_ACCOUNT }}pairtree-service:${{ github.event.release.tag_name }}
+        tags: ${{ vars.DOCKER_REGISTRY_ACCOUNT }}pairtree-service:${{ github.ref_name }}
         build-args: |
           GO_VERSION=${{ env.GO_VERSION }}
           ALPINE_VERSION=${{ env.ALPINE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ on:
   push:
     tags:
       - '*'
-
+  workflow_dispatch:
+    
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Update tag name to properly pull tag from Github. 
- Add workflow_dispatch to docker-related workflows, which will allow for testing of GA workflows in the future without having to merge to main. 